### PR TITLE
Update the command namespace to adr.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,7 @@ All notable changes to BrightComponents/Actions will be documented in this file
 - Add code coverage via CodeClimate.
 - Add duplicate suffix configuration option.
 - Update command to use new configuration option.
+
+## 0.1.2 - 2018-07-26
+
+- Rename command namespace from "bright" to "adr" since the release of the "bright-components/adr" package that combines several bright-components packages.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ return [
 To begin using BrightComponents/Actions, simply follow the instructions above, then generate your Action classes as needed.
 To generate an PostIndex action, as in the example above, enter the following command into your terminal:
 ```bash
-php artisan bright:action Posts\\PostIndex
+php artisan adr:action Posts\\PostIndex
 ```
 
 Place your logic inside the "__invoke" method (or the method name you chose in the configuration file).

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "bright-components/actions",
     "description": "Invokable actions. Not controllers.",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "keywords": [
         "bright-components",
         "actions",

--- a/src/Commands/ActionMakeCommand.php
+++ b/src/Commands/ActionMakeCommand.php
@@ -12,7 +12,7 @@ class ActionMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'bright:action {name}';
+    protected $signature = 'adr:action {name}';
 
     /**
      * The console command description.


### PR DESCRIPTION
- Rename command namespace from "bright" to "adr" since the release of the "bright-components/adr" package that combines several bright-components packages.